### PR TITLE
Change returned values of ReplayBuffer sample method

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ Here's another example of an off-policy training loop in TorchRL (assuming that 
   -     replay_buffer.add((obs, next_obs, action, log_prob, reward, done))
   +     replay_buffer.add(tensordict)
       for j in range(num_optim_steps):
-  -         obs, next_obs, action, hidden_state, reward, done = replay_buffer.sample(batch_size)[0]
+  -         obs, next_obs, action, hidden_state, reward, done = replay_buffer.sample(batch_size)
   -         loss = loss_fn(obs, next_obs, action, hidden_state, reward, done)
-  +         tensordict = replay_buffer.sample(batch_size)[0]
+  +         tensordict = replay_buffer.sample(batch_size)
   +         loss = loss_fn(tensordict)
           loss.backward()
           optim.step()
@@ -334,7 +334,7 @@ The associated [`SafeModule` class](torchrl/modules/tensordict_module/common.py)
     ```python
     from torchrl.objectives import DQNLoss
     loss_module = DQNLoss(value_network=value_network, gamma=0.99)
-    tensordict = replay_buffer.sample(batch_size)[0]
+    tensordict = replay_buffer.sample(batch_size)
     loss = loss_module(tensordict)
     ```
 

--- a/examples/distributed/distributed_replay_buffer.py
+++ b/examples/distributed/distributed_replay_buffer.py
@@ -86,7 +86,7 @@ class DummyTrainerNode:
         for iteration in range(iterations):
             print(f"[{self.id}] Training Iteration: {iteration}")
             time.sleep(3)
-            batch, _ = rpc.rpc_sync(
+            batch = rpc.rpc_sync(
                 self.replay_buffer.owner(),
                 ReplayBufferNode.sample,
                 args=(self.replay_buffer, 16),

--- a/examples/dreamer/dreamer.py
+++ b/examples/dreamer/dreamer.py
@@ -249,7 +249,7 @@ def main(cfg: "DictConfig"):  # noqa: F821
             for j in range(cfg.optim_steps_per_batch):
                 cmpt += 1
                 # sample from replay buffer
-                sampled_tensordict = replay_buffer.sample(cfg.batch_size)[0].to(
+                sampled_tensordict = replay_buffer.sample(cfg.batch_size).to(
                     device, non_blocking=True
                 )
                 if reward_normalizer is not None:

--- a/test/test_rb.py
+++ b/test/test_rb.py
@@ -311,7 +311,7 @@ def test_prototype_prb(priority_key, contiguous, device):
         batch_size=[3],
     ).to(device)
     rb.extend(td1)
-    s, _ = rb.sample(2)
+    s = rb.sample(2)
     assert s.batch_size == torch.Size(
         [
             2,
@@ -330,7 +330,7 @@ def test_prototype_prb(priority_key, contiguous, device):
         batch_size=[5],
     ).to(device)
     rb.extend(td2)
-    s, _ = rb.sample(5)
+    s = rb.sample(5)
     assert s.batch_size == torch.Size([5])
     assert (td2[s.get("_idx").squeeze()].get("a") == s.get("a")).all()
     assert_allclose_td(td2[s.get("_idx").squeeze()].select("a"), s.select("a"))
@@ -353,13 +353,13 @@ def test_prototype_prb(priority_key, contiguous, device):
 
     idx0 = s.get("_idx")[0]
     rb.update_tensordict_priority(s)
-    s, _ = rb.sample(5)
+    s = rb.sample(5)
     assert (val == s.get("a")).sum() >= 1
     torch.testing.assert_close(td2[idx0].get("a").view(1), s.get("a").unique().view(1))
 
     # test updating values of original td
     td2.set_("a", torch.ones_like(td2.get("a")))
-    s, _ = rb.sample(5)
+    s = rb.sample(5)
     torch.testing.assert_close(td2[idx0].get("a").view(1), s.get("a").unique().view(1))
 
 
@@ -381,10 +381,10 @@ def test_replay_buffer_trajectories(stack):
         priority_key="td_error",
     )
     rb.extend(traj_td)
-    sampled_td, _ = rb.sample(3)
+    sampled_td = rb.sample(3)
     sampled_td.set("td_error", torch.rand(3))
     rb.update_tensordict_priority(sampled_td)
-    sampled_td, _ = rb.sample(3, include_info=True)
+    sampled_td = rb.sample(3, include_info=True)
     assert (sampled_td.get("_weight") > 0).all()
     assert sampled_td.batch_size == torch.Size([3])
 
@@ -589,7 +589,7 @@ def test_prb(priority_key, contiguous, device):
         batch_size=[3],
     ).to(device)
     rb.extend(td1)
-    s, _ = rb.sample(2)
+    s = rb.sample(2)
     assert s.batch_size == torch.Size(
         [
             2,
@@ -608,7 +608,7 @@ def test_prb(priority_key, contiguous, device):
         batch_size=[5],
     ).to(device)
     rb.extend(td2)
-    s, _ = rb.sample(5)
+    s = rb.sample(5)
     assert s.batch_size == torch.Size([5])
     assert (td2[s.get("_idx").squeeze()].get("a") == s.get("a")).all()
     assert_allclose_td(td2[s.get("_idx").squeeze()].select("a"), s.select("a"))
@@ -631,13 +631,13 @@ def test_prb(priority_key, contiguous, device):
 
     idx0 = s.get("_idx")[0]
     rb.update_tensordict_priority(s)
-    s, _ = rb.sample(5)
+    s = rb.sample(5)
     assert (val == s.get("a")).sum() >= 1
     torch.testing.assert_close(td2[idx0].get("a").view(1), s.get("a").unique().view(1))
 
     # test updating values of original td
     td2.set_("a", torch.ones_like(td2.get("a")))
-    s, _ = rb.sample(5)
+    s = rb.sample(5)
     torch.testing.assert_close(td2[idx0].get("a").view(1), s.get("a").unique().view(1))
 
 
@@ -657,10 +657,10 @@ def test_rb_trajectories(stack):
         storage=ListStorage(5),
     )
     rb.extend(traj_td)
-    sampled_td, _ = rb.sample(3)
+    sampled_td = rb.sample(3)
     sampled_td.set("td_error", torch.rand(3))
     rb.update_tensordict_priority(sampled_td)
-    sampled_td, _ = rb.sample(3, include_info=True)
+    sampled_td = rb.sample(3, include_info=True)
     assert (sampled_td.get("_weight") > 0).all()
     assert sampled_td.batch_size == torch.Size([3])
 
@@ -724,7 +724,7 @@ def test_append_transform():
 
     rb.append_transform(flatten)
 
-    sampled, _ = rb.sample(1)
+    sampled = rb.sample(1)
     assert sampled.get("observation_cat").shape[-1] == 32
 
 
@@ -737,7 +737,7 @@ def test_init_transform():
 
     td = TensorDict({"observation": torch.randn(2, 4, 3, 16)}, [])
     rb.add(td)
-    sampled, _ = rb.sample(1)
+    sampled = rb.sample(1)
     assert sampled.get("flattened").shape[-1] == 48
 
 
@@ -751,7 +751,7 @@ def test_insert_transform():
 
     rb.insert_transform(0, SqueezeTransform(-1, in_keys=["observation"]))
 
-    sampled, _ = rb.sample(1)
+    sampled = rb.sample(1)
     assert sampled.get("flattened").shape[-1] == 48
 
     with pytest.raises(ValueError):

--- a/torchrl/trainers/trainers.py
+++ b/torchrl/trainers/trainers.py
@@ -669,7 +669,7 @@ class ReplayBufferTrainer(TrainerHookBase):
         self.replay_buffer.extend(batch)
 
     def sample(self, batch: TensorDictBase) -> TensorDictBase:
-        sample, _ = self.replay_buffer.sample(self.batch_size)
+        sample = self.replay_buffer.sample(self.batch_size)
         return sample.to(self.device, non_blocking=True)
 
     def update_priority(self, batch: TensorDictBase) -> None:

--- a/tutorials/sphinx-tutorials/coding_ddpg.py
+++ b/tutorials/sphinx-tutorials/coding_ddpg.py
@@ -645,7 +645,7 @@ for i, tensordict in enumerate(collector):
     if collected_frames >= init_random_frames:
         for _ in range(optim_steps_per_batch):
             # sample from replay buffer
-            sampled_tensordict = replay_buffer.sample(batch_size)[0].clone()
+            sampled_tensordict = replay_buffer.sample(batch_size).clone()
 
             # compute loss for qnet and backprop
             with hold_out_net(actor):
@@ -889,7 +889,7 @@ for i, tensordict in enumerate(collector):
     if collected_frames >= init_random_frames:
         for _ in range(optim_steps_per_batch):
             # sample from replay buffer
-            sampled_tensordict, _ = replay_buffer.sample(batch_size_traj)
+            sampled_tensordict = replay_buffer.sample(batch_size_traj)
             # reset the batch size temporarily, and exclude index whose shape is incompatible with the new size
             index = sampled_tensordict.get("index")
             sampled_tensordict.exclude("index", inplace=True)

--- a/tutorials/sphinx-tutorials/coding_dqn.py
+++ b/tutorials/sphinx-tutorials/coding_dqn.py
@@ -384,7 +384,7 @@ for j, data in enumerate(data_collector):
     if sum(frames) > init_random_frames:
         for _ in range(n_optim):
             # sample from the RB and send to device
-            sampled_data, _ = replay_buffer.sample(batch_size)
+            sampled_data = replay_buffer.sample(batch_size)
             sampled_data = sampled_data.to(device, non_blocking=True)
 
             # collect data from RB
@@ -616,7 +616,7 @@ for j, data in enumerate(data_collector):
 
     if sum(frames) > init_random_frames:
         for _ in range(n_optim):
-            sampled_data, _ = replay_buffer.sample(batch_size // max_size)
+            sampled_data = replay_buffer.sample(batch_size // max_size)
             sampled_data = sampled_data.clone().to(device, non_blocking=True)
 
             reward = sampled_data["reward"]

--- a/tutorials/sphinx-tutorials/torchrl_demo.py
+++ b/tutorials/sphinx-tutorials/torchrl_demo.py
@@ -253,7 +253,7 @@ len(rb)
 rb.extend(TensorDict({"a": torch.randn(2, 3)}, batch_size=[2]))
 print(len(rb))
 print(rb.sample(10))
-print(rb.sample(2)[0].contiguous())
+print(rb.sample(2).contiguous())
 
 ###############################################################################
 
@@ -262,7 +262,7 @@ from torchrl.data import TensorDictPrioritizedReplayBuffer
 
 rb = TensorDictPrioritizedReplayBuffer(alpha=0.7, beta=1.1, priority_key="td_error")
 rb.extend(TensorDict({"a": torch.randn(2, 3)}, batch_size=[2]))
-tensordict_sample = rb.sample(2)[0].contiguous()
+tensordict_sample = rb.sample(2).contiguous()
 tensordict_sample
 
 ###############################################################################


### PR DESCRIPTION
Make `sample()` methods in `ReplayBuffer` and derived classes return only `data` by default and additionally `info` if `return_info=True`.